### PR TITLE
Simplify usage of nalgebra at various places.

### DIFF
--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -53,7 +53,7 @@ impl<'a> System<'a> for AudioSystem {
                 .and_then(|sl| transform.get(sl.0))
                 .or_else(|| transform.get(entity))
             {
-                let listener_transform = listener_transform.0.remove_columns_generic(0, na::U3).remove_row(3);
+                let listener_transform = listener_transform.0.column(3).xyz();
                 let left_ear_position = listener_transform + listener.left_ear;
                 let right_ear_position = listener_transform + listener.right_ear;
                 for (transform, mut audio_emitter) in (&transform, &mut audio_emitter).join() {

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -57,10 +57,9 @@ impl<'a> System<'a> for AudioSystem {
                 let left_ear_position = listener_transform + listener.left_ear;
                 let right_ear_position = listener_transform + listener.right_ear;
                 for (transform, mut audio_emitter) in (&transform, &mut audio_emitter).join() {
-                    let col = transform.0.column(3);
-                    let x = col[0];
-                    let y = col[1];
-                    let z = col[2];
+                    let x = transform.0[(0, 3)];
+                    let y = transform.0[(1, 3)];
+                    let z = transform.0[(2, 3)];
                     let emitter_position = [x, y, z];
                     // Remove all sinks whose sounds have ended.
                     audio_emitter.sinks.retain(|s| !s.1.load(Ordering::Relaxed));

--- a/amethyst_core/src/orientation.rs
+++ b/amethyst_core/src/orientation.rs
@@ -23,8 +23,8 @@ impl From<Matrix3<f32>> for Orientation {
     fn from(mat: Matrix3<f32>) -> Self {
         Orientation {
             forward: -mat.column(0),
-            right: mat.column(1).clone_owned(),
-            up: mat.column(2).clone_owned(),
+            right: mat.column(1).into(),
+            up: mat.column(2).into(),
         }
     }
 }
@@ -33,9 +33,9 @@ impl Default for Orientation {
     fn default() -> Self {
         // Signs depend on coordinate system
         Self {
-            forward: -Vector3::new(na::zero(), na::zero(), na::one()),
-            right: Vector3::new(na::one(), na::zero(), na::zero()),
-            up: Vector3::new(na::zero(), na::one(), na::zero()),
+            forward: -Vector3::z(),
+            right: Vector3::x(),
+            up: Vector3::y(),
         }
     }
 }

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -56,15 +56,8 @@ impl Transform {
     // TODO: fix example
     #[inline]
     pub fn look_at(&mut self, target: Vector3<f32>, up: Vector3<f32>) -> &mut Self {
-        /*
-         * Are you sure you actually want the look_at matrix here? It is worth noting this will
-         * generate a look_at view matrix (intended to be used by a camera). So that might
-         * be the inverse of what you intended to do here.
-         * You should try `new_observer_frame` (https://www.nalgebra.org/rustdoc/nalgebra/geometry/type.UnitQuaternion.html#method.new_observer_frame)
-         * instead.
-         */
         self.iso.rotation =
-            UnitQuaternion::look_at_rh(&(self.iso.translation.vector - target), &up);
+            UnitQuaternion::look_at_rh(&(target - self.iso.translation.vector), &up);
         self
     }
 

--- a/amethyst_renderer/src/pass/debug_lines/interleaved.rs
+++ b/amethyst_renderer/src/pass/debug_lines/interleaved.rs
@@ -116,7 +116,7 @@ where
             "camera_position",
             camera
                 .as_ref()
-                .map(|&(_, ref trans)| trans.0.column(3).remove_row(3).into())
+                .map(|&(_, ref trans)| trans.0.column(3).xyz().into())
                 .unwrap_or([0.0; 3]),
         );
 

--- a/amethyst_renderer/src/pass/shaded_util.rs
+++ b/amethyst_renderer/src/pass/shaded_util.rs
@@ -40,7 +40,7 @@ pub(crate) fn set_light_args(
         .join()
         .filter_map(|(light, transform)| {
             if let Light::Point(ref light) = *light {
-                let position: [f32; 3] = transform.0.column(3).remove_row(3).into();
+                let position: [f32; 3] = transform.0.column(3).xyz().into();
                 Some(
                     PointLightPod {
                         position: position.into(),
@@ -84,7 +84,7 @@ pub(crate) fn set_light_args(
         "camera_position",
         camera
             .as_ref()
-            .map(|&(_, ref trans)| trans.0.column(3).remove_row(3).into())
+            .map(|&(_, ref trans)| trans.0.column(3).xyz().into())
             .unwrap_or([0.0; 3]),
     );
 }

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -291,8 +291,6 @@ impl SpriteBatch {
 
             let dir_x = transform.column(0) * sprite_data.width;
             let dir_y = transform.column(1) * sprite_data.height;
-            let dir_x = dir_x.as_slice();
-            let dir_y = dir_y.as_slice();
 
             // The offsets are negated to shift the sprite left and down relative to the entity, in
             // regards to pivot points. This is the convention adopted in:
@@ -303,7 +301,7 @@ impl SpriteBatch {
                 * Vector4::new(-sprite_data.offsets[0], -sprite_data.offsets[1], 0.0, 1.0);
 
             instance_data.extend(&[
-                dir_x[0], dir_x[1], dir_y[0], dir_y[1], pos.x, pos.y, uv_left, uv_right, uv_bottom,
+                dir_x.x, dir_x.y, dir_y.x, dir_y.y, pos.x, pos.y, uv_left, uv_right, uv_bottom,
                 uv_top, pos.z,
             ]);
             num_instances += 1;

--- a/amethyst_renderer/src/shape.rs
+++ b/amethyst_renderer/src/shape.rs
@@ -232,7 +232,7 @@ where
                     .map(|(x, y, z)| {
                         Vector3::new(v.normal.x * x, v.normal.y * y, v.normal.z * z).normalize()
                     }).unwrap_or_else(|| Vector3::from(v.normal));
-                let up = Vector3::new(0.0, 1.0, 0.0);
+                let up = Vector3::y();
                 let tangent = normal.cross(&up).cross(&normal);
                 (
                     pos.into(),

--- a/amethyst_renderer/src/sprite_visibility.rs
+++ b/amethyst_renderer/src/sprite_visibility.rs
@@ -72,7 +72,7 @@ impl<'a> System<'a> for SpriteVisibilitySortingSystem {
             .and_then(|a| global.get(a.entity))
             .or_else(|| (&camera, &global).join().map(|cg| cg.1).next());
         let camera_backward = camera
-            .map(|c| c.0.column(2).remove_row(3).into())
+            .map(|c| c.0.column(2).xyz().into())
             .unwrap_or_else(Vector3::z);
         let camera_centroid = camera
             .map(|g| g.0.fixed_resize::<na::U3, na::U3>(0.0) * origin)

--- a/amethyst_renderer/src/visibility.rs
+++ b/amethyst_renderer/src/visibility.rs
@@ -68,7 +68,7 @@ impl<'a> System<'a> for VisibilitySortingSystem {
             .and_then(|a| global.get(a.entity))
             .or_else(|| (&camera, &global).join().map(|cg| cg.1).next());
         let camera_backward = camera
-            .map(|c| c.0.column(2).remove_row(3))
+            .map(|c| c.0.column(2).xyz())
             .unwrap_or_else(Vector3::z);
         let camera_centroid = camera
             .map(|g| g.0.fixed_resize::<na::U3, na::U3>(0.0) * origin)

--- a/examples/appendix_a/pong.rs
+++ b/examples/appendix_a/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::Loader,
     core::{
-        nalgebra::{Translation, Vector3},
+        nalgebra::{Translation3, Vector3},
         transform::{GlobalTransform, Transform},
     },
     ecs::prelude::World,
@@ -46,7 +46,7 @@ fn initialise_camera(world: &mut World) {
             arena_height,
             0.0,
         ))).with(GlobalTransform(
-            Translation::from_vector(Vector3::new(0.0, 0.0, 1.0)).to_homogeneous(),
+            Translation3::new(0.0, 0.0, 1.0).to_homogeneous(),
         )).build();
 }
 

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Loader},
     core::{
-        nalgebra::{Translation, Vector3},
+        nalgebra::{Translation3, Vector3},
         transform::{GlobalTransform, Transform},
     },
     ecs::prelude::World,
@@ -125,7 +125,7 @@ fn initialise_camera(world: &mut World) {
             0.0,
         )))
         .with(GlobalTransform(
-            Translation::from_vector(Vector3::new(0.0, 0.0, 1.0)).to_homogeneous(),
+            Translation3::new(0.0, 0.0, 1.0).to_homogeneous(),
         ))
         .build();
 }

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -244,11 +244,8 @@ impl<'a> System<'a> for ExampleSystem {
         let delta_rot =
             UnitQuaternion::from_axis_angle(&Vector3::z_axis(), camera_angular_velocity * time.delta_seconds());
         for (_, transform) in (&camera, &mut transforms).join() {
-            // rotate the camera, using the origin as a pivot point
-            *transform.translation_mut() = delta_rot * transform.translation();
-            // add the delta rotation for the frame to the total rotation (quaternion multiplication
-            // is the same as rotational addition)
-            *transform.rotation_mut() = delta_rot * transform.rotation();
+            // Append the delta rotation to the current transform.
+            *transform.isometry_mut() = delta_rot * transform.isometry()
         }
 
         for (point_light, transform) in

--- a/examples/sprites/main.rs
+++ b/examples/sprites/main.rs
@@ -309,9 +309,7 @@ fn initialise_camera(world: &mut World) -> Entity {
         .create_entity()
         .with(Camera::from(Projection::orthographic(
             0.0, width, height, 0.0,
-        ))).with(GlobalTransform(Matrix4::new_translation(&Vector3::new(
-            0.0, 0.0, 1.0,
-        )))).build()
+        ))).with(GlobalTransform(Matrix4::new_translation(&Vector3::z()))).build()
 }
 
 fn main() -> amethyst::Result<()> {


### PR DESCRIPTION
This PR shows various proposals for a simpler use of nalgebra. Two elements require some attention:

1. I've added a comment on `local_transform.rs` for the [look_at](https://github.com/magnonellie/amethyst/compare/nalgebra...sebcrozet:nalgebra?expand=1#diff-4c21774c954af6887112023c383d22b6R59) method. I am not sure `.look_at_rh` is what you were looking for there.
2. I have removed the division by the magnitude [there](https://github.com/magnonellie/amethyst/compare/nalgebra...sebcrozet:nalgebra?expand=1#diff-4c21774c954af6887112023c383d22b6L139) because the `direction` is already a unit vector. Thus its norm should already be 1.