### PR TITLE
Use `transform_point` to calculate centroid.

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-nalgebra = { version = "0.16", features = ["serde-serialize", "mint"] }
+nalgebra = { version = "0.16.7", features = ["serde-serialize", "mint"] }
 approx = "0.3"
 error-chain = "0.12"
 fnv = "1"

--- a/amethyst_renderer/src/sprite_visibility.rs
+++ b/amethyst_renderer/src/sprite_visibility.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use amethyst_core::nalgebra::{self as na, Point3, Vector3};
+use amethyst_core::nalgebra::{Point3, Vector3};
 use amethyst_core::specs::prelude::{Entities, Entity, Join, Read, ReadStorage, System, Write};
 use amethyst_core::GlobalTransform;
 use hibitset::BitSet;
@@ -63,7 +63,7 @@ impl<'a> System<'a> for SpriteVisibilitySortingSystem {
     fn run(
         &mut self,
         (entities, mut visibility, hidden, hidden_prop, active, camera, transparent, global): Self::SystemData,
-){
+    ) {
         let origin = Point3::origin();
 
         // The camera position is used to determine culling, but the sprites are ordered based on
@@ -75,19 +75,15 @@ impl<'a> System<'a> for SpriteVisibilitySortingSystem {
             .map(|c| c.0.column(2).xyz().into())
             .unwrap_or_else(Vector3::z);
         let camera_centroid = camera
-            .map(|g| g.0.fixed_resize::<na::U3, na::U3>(0.0) * origin)
+            .map(|g| g.0.transform_point(&origin))
             .unwrap_or_else(|| origin);
 
         self.centroids.clear();
         self.centroids.extend(
             (&*entities, &global, !&hidden, !&hidden_prop)
                 .join()
-                .map(|(entity, global, _, _)| {
-                    (
-                        entity,
-                        global.0.fixed_resize::<na::U3, na::U3>(0.0) * origin,
-                    )
-                }).map(|(entity, centroid)| Internals {
+                .map(|(entity, global, _, _)| (entity, global.0.transform_point(&origin)))
+                .map(|(entity, centroid)| Internals {
                     entity,
                     transparent: transparent.contains(entity),
                     centroid,

--- a/amethyst_renderer/src/visibility.rs
+++ b/amethyst_renderer/src/visibility.rs
@@ -61,7 +61,7 @@ impl<'a> System<'a> for VisibilitySortingSystem {
     fn run(
         &mut self,
         (entities, mut visibility, hidden, hidden_prop, active, camera, transparent, global): Self::SystemData,
-){
+    ) {
         let origin = Point3::origin();
 
         let camera: Option<&GlobalTransform> = active
@@ -71,25 +71,22 @@ impl<'a> System<'a> for VisibilitySortingSystem {
             .map(|c| c.0.column(2).xyz())
             .unwrap_or_else(Vector3::z);
         let camera_centroid = camera
-            .map(|g| g.0.fixed_resize::<na::U3, na::U3>(0.0) * origin)
+            .map(|g| g.0.transform_point(&origin))
             .unwrap_or_else(|| origin);
 
         self.centroids.clear();
         self.centroids.extend(
             (&*entities, &global, !&hidden, !&hidden_prop)
                 .join()
-                .map(|(entity, global, _, _)| {
-                    (
-                        entity,
-                        global.0.fixed_resize::<na::U3, na::U3>(0.0) * origin,
-                    )
-                }).map(|(entity, centroid)| Internals {
+                .map(|(entity, global, _, _)| (entity, global.0.transform_point(&origin)))
+                .map(|(entity, centroid)| Internals {
                     entity,
                     transparent: transparent.contains(entity),
                     centroid,
                     camera_distance: na::distance_squared(&centroid, &camera_centroid),
                     from_camera: centroid - camera_centroid,
-                }).filter(|c| c.from_camera.dot(&camera_backward) < 0.), // filter entities behind the camera
+                })
+                .filter(|c| c.from_camera.dot(&camera_backward) < 0.), // filter entities behind the camera
         );
         self.transparent.clear();
         self.transparent


### PR DESCRIPTION
*Outdated*

> This requires importing the `alga` crate as `nalgebra` doesn't re-export the `Transformation` trait.
>
> Perhaps we should update `nalgebra` to re-export the trait instead. That's probably cleaner -- we don't need to monitor dependencies of dependencies. @sebcrozet does that make sense?